### PR TITLE
otlp: replace imports in generate files

### DIFF
--- a/otlp/collector/logs/v1/logs_service.pb.go
+++ b/otlp/collector/logs/v1/logs_service.pb.go
@@ -21,7 +21,7 @@
 package v1
 
 import (
-	v1 "go.opentelemetry.io/proto/otlp/logs/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/logs/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/collector/metrics/v1/metrics_service.pb.go
+++ b/otlp/collector/metrics/v1/metrics_service.pb.go
@@ -21,7 +21,7 @@
 package v1
 
 import (
-	v1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/metrics/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/collector/trace/v1/trace_service.pb.go
+++ b/otlp/collector/trace/v1/trace_service.pb.go
@@ -21,7 +21,7 @@
 package v1
 
 import (
-	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/trace/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/go.mod
+++ b/otlp/go.mod
@@ -1,4 +1,4 @@
-module go.opentelemetry.io/proto/otlp
+module github.com/tailscale/opentelemetry-proto-go/otlp
 
 go 1.14
 

--- a/otlp/logs/v1/logs.pb.go
+++ b/otlp/logs/v1/logs.pb.go
@@ -21,8 +21,8 @@
 package v1
 
 import (
-	v11 "go.opentelemetry.io/proto/otlp/common/v1"
-	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	v11 "github.com/tailscale/opentelemetry-proto-go/otlp/common/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/resource/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/metrics/v1/metrics.pb.go
+++ b/otlp/metrics/v1/metrics.pb.go
@@ -21,8 +21,8 @@
 package v1
 
 import (
-	v11 "go.opentelemetry.io/proto/otlp/common/v1"
-	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	v11 "github.com/tailscale/opentelemetry-proto-go/otlp/common/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/resource/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/resource/v1/resource.pb.go
+++ b/otlp/resource/v1/resource.pb.go
@@ -21,7 +21,7 @@
 package v1
 
 import (
-	v1 "go.opentelemetry.io/proto/otlp/common/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/common/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/otlp/trace/v1/trace.pb.go
+++ b/otlp/trace/v1/trace.pb.go
@@ -21,8 +21,8 @@
 package v1
 
 import (
-	v11 "go.opentelemetry.io/proto/otlp/common/v1"
-	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	v11 "github.com/tailscale/opentelemetry-proto-go/otlp/common/v1"
+	v1 "github.com/tailscale/opentelemetry-proto-go/otlp/resource/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"


### PR DESCRIPTION
This change replaces the imports in the generated files to point to our
forked version.

This will be followed up with a PR to the `Makefile` generation targets to adjust the import path